### PR TITLE
Remove chalk and emojic from socket output

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testPathIgnorePatterns: [
-    '<rootDir>/src/__tests__/',
+    '<rootDir>/node_modules/',
     '<rootDir>/build/',
     'supergoose',
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,6 +885,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1466,15 +1467,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
-    "camelo": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/camelo/-/camelo-1.1.12.tgz",
-      "integrity": "sha512-qyY6IgFJUglfYeyL5drpjFMbaRjFRTTFeYRmoSkOCf+lazypMz3IcZk4HaE2NZra/b9XdSQi2W01HmaZymNoxA==",
-      "requires": {
-        "regex-escape": "^3.3.0",
-        "uc-first-array": "^1.0.0"
-      }
-    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -1499,6 +1491,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1694,6 +1687,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1701,7 +1695,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2244,22 +2239,6 @@
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
-    },
-    "emojic": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/emojic/-/emojic-1.1.15.tgz",
-      "integrity": "sha512-Rm2fQkSfPmCI9Gf876L4LVxvmBzTp+F5MPo9pxkJlXaU0MAOOeT0bPcqX3NMugMI80IdYlthfeMMBWfU+/54LQ==",
-      "requires": {
-        "camelo": "^1.0.0",
-        "emojilib": "^2.0.2",
-        "iterate-object": "^1.2.0",
-        "r-json": "^1.1.0"
-      }
-    },
-    "emojilib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -4391,11 +4370,6 @@
         "handlebars": "^4.1.2"
       }
     },
-    "iterate-object": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.3.tgz",
-      "integrity": "sha512-DximWbkke36cnrSfNJv6bgcB2QOMV9PRD2FiowwzCoMsh8RupFLdbNIzWe+cVDWT+NIMNJgGlB1dGxP6kpzGtA=="
-    },
     "jacoco-parse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jacoco-parse/-/jacoco-parse-2.0.1.tgz",
@@ -6487,11 +6461,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
-    "r-json": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/r-json/-/r-json-1.2.9.tgz",
-      "integrity": "sha512-E5u25XBE7PpZmH5XwtthAmNvSLMTygDQMpcPtCTUBdvwPaqgIYJrxlRQJhG55Sgz7uC0Tuyh5nqNrsDT3uiefA=="
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6626,11 +6595,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
       "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
       "dev": true
-    },
-    "regex-escape": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/regex-escape/-/regex-escape-3.4.9.tgz",
-      "integrity": "sha512-Cv9rjwyQwVhn3L097ysanWsEElurmxDj6Cc4Ut23z7e6hzRbrNvF3Le7yAciMfuzyb0sZwSr0ZHunMNCIoy2/g=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7626,6 +7590,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -8105,19 +8070,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
       "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
-    },
-    "uc-first-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/uc-first-array/-/uc-first-array-1.1.9.tgz",
-      "integrity": "sha512-RHBUloM1Onz7ZKplDU0FWIXWHxU8Ylztw/ORsFY/py6If5B+8PWd39j9ll+i8jUaAAs2Rs2lKMbxvm4u8Q2dbg==",
-      "requires": {
-        "ucfirst": "^1.0.0"
-      }
-    },
-    "ucfirst": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ucfirst/-/ucfirst-1.0.0.tgz",
-      "integrity": "sha1-ThBbZEjQXiZOzsQ14LkZNjxfLy8="
     },
     "uglify-js": {
       "version": "3.5.15",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "npm": ">= 6.9.0"
   },
   "scripts": {
-    "start": "ts-node index.ts",
+    "start": "ts-node src/index.ts",
     "watch": "nodemon --config './nodemon.json'",
     "test": "jest --coverage --verbose",
     "test-watch": "jest --coverage --verbose --watch",

--- a/package.json
+++ b/package.json
@@ -41,11 +41,9 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
-    "chalk": "^2.4.2",
     "codacy-coverage": "^3.4.0",
     "cors": "^2.8.5",
     "dotenv": "^8.0.0",
-    "emojic": "^1.1.15",
     "express": "^4.17.1",
     "mongoose": "^5.5.11",
     "mongoose-schema-jsonschema": "^1.2.1",

--- a/src/events/command-handlers/about.ts
+++ b/src/events/command-handlers/about.ts
@@ -9,11 +9,7 @@ import sendToUser from '../lib/send-to-user'
  * @param io The server-side Socket.io instance
  */
 
-const about: (arg: null, socket: Socket, io: Server) => void = (
-  arg: null,
-  socket: Socket,
-  io: Server
-): void => {
+const about = (arg: null = null, socket: Socket, io: Server): void => {
   const message = `
 ==================================
 _        _    _         _    

--- a/src/events/command-handlers/details.ts
+++ b/src/events/command-handlers/details.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import {
@@ -13,29 +12,29 @@ import sendToUser from '../lib/send-to-user'
 /**
  * Display details to the user including their username,
  * their room, and the users they're with.
- * @param arg {null} Unused parameter
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg Unused parameter
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
-const details = (arg: null, socket: Socket, io: Server): void => {
+const details = (arg: null = null, socket: Socket, io: Server): void => {
   const populationDetails: IGetDetails = population.getDetails()
   const room: TRoomName = population.getRoom(socket.id)
   const username: TUsername = population.getUsername(socket.id)
   const users: string = populationDetails.usernamesPerRoom[room]
     .filter((user: TUsername) => user !== username)
-    .map((user: TUsername) => chalk.cyan(user))
+    .map((user: TUsername) => user)
     .join(', ') // This string will look like an array
   const leaderId: TSocketId = population.getLeader(room)
-  const leader: TUsername = chalk.cyan(population.getUsername(leaderId))
+  const leader: TUsername = population.getUsername(leaderId)
 
   if (populationDetails.userCountPerRoom[room] > 0) {
     const message: string = `
-  Your Socket.io client id is ${chalk.cyan(socket.id)}
-  Your username is ${chalk.cyan(username)}
-  You are one of ${chalk.cyan(
-    populationDetails.userCountPerRoom[room].toString()
-  )} users in ${chalk.cyan(room)}
-  Other users in the room are: ${users.length > 0 ? users : chalk.cyan('n/a')}
+  Your Socket.io client id is ${socket.id}
+  Your username is ${username}
+  You are one of ${populationDetails.userCountPerRoom[
+    room
+  ].toString()} users in ${room}
+  Other users in the room are: ${users.length > 0 ? users : 'n/a'}
   The leader of your room is ${leader}
   `
     sendToUser(message, socket, io, null)

--- a/src/events/command-handlers/fallback.ts
+++ b/src/events/command-handlers/fallback.ts
@@ -1,21 +1,16 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import sendToUser from '../lib/send-to-user'
 
 /**
  * Warn the user when they have used an invalid command
- * @exports
- * @function
- * @name fallback
- * @param arg {null} Unused parameter
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg Unused parameter
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const fallback = (arg: null = null, socket: Socket, io: Server): void => {
-  const message: string = `Type ${chalk.cyan(
-    '/help'
-  )} to see a list of available commands.\n`
+  const message: string = `Type ${'/help'} to see a list of available commands.\n`
+
   sendToUser(message, socket, io, null)
 }
 

--- a/src/events/command-handlers/help.ts
+++ b/src/events/command-handlers/help.ts
@@ -1,39 +1,28 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
-// const emojic = require('emojic');
 import sendToUser from '../lib/send-to-user'
 
 const instructions: string = `
-${chalk.underline.bold('Chat Commands')}
+${'Chat Commands'}
 /about ← See information about the Hubbub projects and development team
 /details ← See your name, the room you're in, and a list of other users in your current room
 /exit ← Disconnect from the server and exit the program
 /help ← This menu
-/launch ${chalk.green('url')} ← Run the application at ${chalk.green('url')}! ${
-  '::rocket::' /* emojic.rocket */
-}
+/launch 'url' ← Run the application at 'url'!
 /leave ← Return to the chat lobby from within the chat
 /list ← See a list of external applications you can run
 /lobby ← Reconnect to the chat server
-/join ${chalk.blue('room')} ← Join the ongoing chat in ${chalk.blue('room')}
-/me :D ← Emotes lamely. ${chalk.magenta(':D')}
-/msg ${chalk.yellow('user')} ← Send a direct message to ${chalk.yellow('user')}
-/nick ${chalk.cyan('username')} ← Update your username to ${chalk.cyan(
-  'username'
-)}
-/room ${chalk.green(
-  'name'
-)} ← Create and automatically join a room called ${chalk.green('name')}\n`
+/join 'room' ← Join the ongoing chat in 'room'
+/me :D ← Emotes lamely. ':D'
+/msg 'user' ← Send a direct message to 'user'
+/nick 'username' ← Update your username to 'username'
+/room 'name' ← Create and automatically join a room called 'name'\n`
 
 /**
  * Display a list of available commands to the user
- * @exports
- * @function
- * @name help
- * @param arg {null} Unused parameter
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg Unused parameter
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const help = (arg: null = null, socket: Socket, io: Server): void => {
   sendToUser(instructions, socket, io, null)

--- a/src/events/command-handlers/join.ts
+++ b/src/events/command-handlers/join.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import { TRoomName, TSocketId, TUsername } from '../../types/global'
@@ -8,12 +7,9 @@ import sendToUser from '../lib/send-to-user'
 
 /**
  * Move a user to an extant room if appropriate
- * @exports
- * @function
- * @name join
- * @param arg {string} The name of the room to join
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg The name of the room to join
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const join = (arg: string, socket: Socket, io: Server): void => {
   const username: TUsername = population.getUsername(socket.id)
@@ -23,7 +19,8 @@ const join = (arg: string, socket: Socket, io: Server): void => {
 
   if (!isRoom) {
     // The room does not exist
-    const message: string = `The room ${chalk.cyan(newRoom)} does not exist.`
+    const message: string = `The room ${newRoom} does not exist.`
+
     sendToUser(message, socket, io, null)
     return
   }
@@ -38,31 +35,27 @@ const join = (arg: string, socket: Socket, io: Server): void => {
 
     // Send a message to the user
     const newLeaderId: TSocketId = population.getLeader(newRoom)
-    const newLeader: TUsername = chalk.cyan(population.getUsername(newLeaderId))
-    const message: string = `You have left ${chalk.red(
-      oldRoom
-    )} and joined ${chalk.green(newRoom)}
+    const newLeader: TUsername = population.getUsername(newLeaderId)
+    const message: string = `You have left ${oldRoom} and joined ${newRoom}
 The leader of your room is ${newLeader}`
     sendToUser(message, socket, io, null)
 
     // Send a message to the room they're leaving
     const oldLeaderId: TSocketId = population.getLeader(oldRoom)
-    const oldLeader: TUsername = chalk.cyan(population.getUsername(oldLeaderId))
-    const oldRoomMessage: string = `${username} has left ${chalk.red(
-      oldRoom
-    )} and joined ${chalk.green(newRoom)}
+    const oldLeader: TUsername = population.getUsername(oldLeaderId)
+    const oldRoomMessage: string = `${username} has left ${oldRoom} and joined ${newRoom}
 The leader of your room is ${oldLeader}`
     sendToRoom(oldRoomMessage, oldRoom, socket)
 
     // Send a message to their new room
-    const newRoomMessage: string = `${username} has joined you in ${chalk.green(
-      newRoom
-    )}`
+    const newRoomMessage: string = `${username} has joined you in ${newRoom}`
+
     sendToRoom(newRoomMessage, newRoom, socket)
     // If the user is already in the room
   } else if (oldRoom === newRoom) {
     // Send a message to the user
-    const message: string = `You are already in ${chalk.cyan(newRoom)}`
+    const message: string = `You are already in ${newRoom}`
+
     sendToUser(message, socket, io, null)
   }
 }

--- a/src/events/command-handlers/launch.ts
+++ b/src/events/command-handlers/launch.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import sendToUser from '../lib/send-to-user'
@@ -7,20 +6,15 @@ import sendToUser from '../lib/send-to-user'
  * Launch fallback
  * If the `/launch` command was entered without an argument,
  * users will see this message.
- * @exports
- * @function
- * @name launch
- * @param [arg=null] {null} Unused parameter
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg Unused parameter
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const launch = (arg: null = null, socket: Socket, io: Server): void => {
-  const message: string = `Make sure to enter the link to the application after ${chalk.cyan(
-    '/launch'
-  )}
-For example:
-${chalk.cyan(`/launch ${process.env.EXAMPLE_APP}`)}
+  const message: string = `Make sure to enter the link to the application after '/launch'
+For example: /launch ${process.env.EXAMPLE_APP}
 `
+
   sendToUser(message, socket, io, null)
 }
 

--- a/src/events/command-handlers/leave.ts
+++ b/src/events/command-handlers/leave.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import { TRoomName, TSocketId, TUsername } from '../../types/global'
@@ -8,12 +7,9 @@ import sendToUser from '../lib/send-to-user'
 
 /**
  * Move a user from a room to the Lobby
- * @exports
- * @function
- * @name leave
- * @param arg {null} Unused parameter
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg Unused parameter
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const leave = (arg: null = null, socket: Socket, io: Server): void => {
   const username = population.getUsername(socket.id)
@@ -30,28 +26,24 @@ const leave = (arg: null = null, socket: Socket, io: Server): void => {
     socket.join(newRoom)
 
     // Send a message to the user
-    const message: string = `You have left ${chalk.red(
-      oldRoom
-    )} and joined ${chalk.green(newRoom)}`
+    const message: string = `You have left ${oldRoom} and joined ${newRoom}`
     sendToUser(message, socket, io, null)
 
     // Send a message to the room they're leaving
     const leaderId: TSocketId = population.getLeader(oldRoom)
-    const leader: TUsername = chalk.cyan(population.getUsername(leaderId))
-    const oldRoomMessage: string = `${username} has left ${chalk.red(
-      oldRoom
-    )} and joined ${chalk.green(newRoom)}
+    const leader: TUsername = population.getUsername(leaderId)
+    const oldRoomMessage: string = `${username} has left ${oldRoom} and joined ${newRoom}
 The leader of your room is ${leader}`
+
     sendToRoom(oldRoomMessage, oldRoom, socket)
 
     // Send a message to their new room
-    const newRoomMessage: string = `${username} has joined you in ${chalk.green(
-      newRoom
-    )}`
+    const newRoomMessage: string = `${username} has joined you in ${newRoom}`
+
     sendToRoom(newRoomMessage, newRoom, socket)
   } else {
     // Send a message to the user
-    const message: string = `You are already in ${chalk.cyan(newRoom)}`
+    const message: string = `You are already in ${newRoom}`
     sendToUser(message, socket, io, null)
   }
 }

--- a/src/events/command-handlers/me.ts
+++ b/src/events/command-handlers/me.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import { TRoomName, TUsername } from '../../types/global'
@@ -8,17 +7,15 @@ import sendToUser from '../lib/send-to-user'
 
 /**
  * Emit a user text-emote to their room ::shrugs::
- * @exports
- * @function
- * @name me
- * @param arg {string} The text-emote
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg The text-emote
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const me = (arg: string, socket: Socket, io: Server): void => {
   const room: TRoomName = population.getRoom(socket.id)
   const username: TUsername = population.getUsername(socket.id)
-  const emote: string = chalk.magenta(`[${username}] ${arg}`)
+  const emote: string = `[${username}] ${arg}`
+
   sendToUser(emote, socket, io, socket.id)
   sendToRoom(emote, room, socket)
 }

--- a/src/events/command-handlers/msg.ts
+++ b/src/events/command-handlers/msg.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import { TSocketId, TUsername } from '../../types/global'
@@ -7,12 +6,9 @@ import sendToUser from '../lib/send-to-user'
 
 /**
  * Send a direct message from a user to a recipient
- * @exports
- * @function
- * @name msg
- * @param arg {string} The username of and message to an intended recipient
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg The username of and message to an intended recipient
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const msg = (arg: string, socket: Socket, io: Server): void => {
   const username: TUsername = population.getUsername(socket.id)
@@ -26,15 +22,14 @@ const msg = (arg: string, socket: Socket, io: Server): void => {
 
     // If the recipient exists, send the message to them
     if (recipientId) {
-      const designator: string = chalk.magenta(`[${username} → ${recipient}]`)
+      const designator: string = `[${username} → ${recipient}]`
       const msgArg: string = arg.slice(recipient.length, arg.length)
       const message: string = designator + msgArg
       sendToUser(message, socket, io, recipientId)
     } else {
       // Else inform the user of the problem
-      const message: string = chalk.red(
-        `The user '${recipient}' does not exist`
-      )
+      const message: string = `The user '${recipient}' does not exist`
+
       sendToUser(message, socket, io, null)
     }
   }

--- a/src/events/command-handlers/nick.ts
+++ b/src/events/command-handlers/nick.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import { TRoomName, TUsername } from '../../types/global'
@@ -8,12 +7,9 @@ import sendToUser from '../lib/send-to-user'
 
 /**
  * Reassign a username to a custom nickname, if it's not taken
- * @exports
- * @function
- * @name nick
- * @param arg {string} The proposed new username
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg The proposed new username
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const nick = (arg: string, socket: Socket, io: Server): void => {
   const oldName: TUsername = population.getUsername(socket.id)
@@ -21,19 +17,16 @@ const nick = (arg: string, socket: Socket, io: Server): void => {
 
   // Don't allow duplicate usernames
   if (isTaken) {
-    const userMessage: string = `The username ${chalk.cyan(
-      arg
-    )} is not available`
+    const userMessage: string = `The username ${arg} is not available`
     sendToUser(userMessage, socket, io, null)
   } else {
     population.addUser(socket.id, arg)
-    const name: TUsername = chalk.yellow(arg)
+    const name: TUsername = arg
     const room: TRoomName = population.getRoom(socket.id)
 
     // Send to room
-    const roomAnnouncement: string = `${chalk.red(
-      oldName
-    )} has updated their name to ${name}`
+    const roomAnnouncement: string = `${oldName} has updated their name to ${name}`
+
     sendToRoom(roomAnnouncement, room, socket)
 
     // Send to user

--- a/src/events/command-handlers/room.ts
+++ b/src/events/command-handlers/room.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Server, Socket } from 'socket.io'
 
 import { TRoomName, TUsername } from '../../types/global'
@@ -8,12 +7,9 @@ import sendToUser from '../lib/send-to-user'
 
 /**
  * Create a new room and add a user to it, if appropriate
- * @exports
- * @function
- * @name room
- * @param arg {string} The name of the new room
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param arg The name of the new room
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  */
 const room = (arg: string, socket: Socket, io: Server): void => {
   const username: TUsername = population.getUsername(socket.id)
@@ -32,23 +28,22 @@ const room = (arg: string, socket: Socket, io: Server): void => {
     socket.join(newRoom)
 
     // Send a message to the user
-    const message: string = `You have left ${chalk.red(
-      oldRoom
-    )} and created ${chalk.green(newRoom)}
-You are now the leader of ${chalk.green(newRoom)}`
+    const message: string = `You have left ${oldRoom} and created ${newRoom}
+You are now the leader of ${newRoom}`
+
     sendToUser(message, socket, io, null)
 
     // Send a message to the room they're leaving, if it hasn't closed
     if (population.isRoom(oldRoom)) {
-      const oldRoomMessage: string = `${username} has left ${chalk.red(
-        oldRoom
-      )} and joined ${chalk.green(newRoom)}`
+      const oldRoomMessage: string = `${username} has left ${oldRoom} and joined ${newRoom}`
+
       sendToRoom(oldRoomMessage, oldRoom, socket)
     }
     // If the user is already in the room
   } else if (oldRoom === newRoom) {
     // Send a message to the user
-    const message: string = `You are already in ${chalk.cyan(newRoom)}`
+    const message: string = `You are already in ${newRoom}`
+
     sendToUser(message, socket, io, null)
   }
 }

--- a/src/events/event-handlers/handle-connection.ts
+++ b/src/events/event-handlers/handle-connection.ts
@@ -1,34 +1,20 @@
-import chalk from 'chalk'
-// import emojic from 'emojic';
 import { hacker } from 'faker'
 const { noun } = hacker
 import { Server, Socket } from 'socket.io'
 
 import { TUsername } from '../../types/global'
-
 import sendToRoom from '../lib/send-to-room'
 import sendToUser from '../lib/send-to-user'
 
 // This is in-memory storage of the current chat environment
 import population from '../lib/population'
 
-/**
- * Set a standard greeting, given a username
- * @exports
- * @function
- * @name setGreeting
- * @param username {string} The user's username
- * @returns {string}
- */
+/** Set a standard greeting, given a username */
 export const setGreeting = (username: TUsername): string => {
-  // const smiley = chalk.bold.yellow(emojic.grin);
-  // const wave = chalk.bold.yellow(emojic.wave);
-  const welcome: string = chalk.underline.bold.white(`Welcome to Hubbub!`)
-  const main: string = `\n${'' /* smiley */} ${welcome} ${'' /* wave */}\n`
-  const usernameMsg: string = `Your username is ${chalk.cyan(username)}\n`
-  const help: string = `Type ${chalk.cyan(
-    '/help'
-  )} to see a list of commands.\n`
+  const welcome: string = `Welcome to Hubbub!`
+  const main: string = `\n${welcome}\n`
+  const usernameMsg: string = `Your username is ${username}\n`
+  const help: string = `Type ${'/help'} to see a list of commands.\n`
   const greeting: string = main + usernameMsg + help
   return greeting
 }
@@ -36,10 +22,8 @@ export const setGreeting = (username: TUsername): string => {
 /***
  * On socket connection, greet the user, add them to the lobby,
  * and announce their presence to the lobby.
- * @function
- * @name handleConnection
- * @param socket {object} The socket object from the client event
- * @param io {object} The server-side Socket.io instance
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  ***/
 const handleConnection = (socket: Socket, io: Server): void => {
   // Create a random username
@@ -56,7 +40,8 @@ const handleConnection = (socket: Socket, io: Server): void => {
   sendToUser(welcome, socket, io, null)
 
   // Announce the new user to their room
-  const message: string = `${chalk.yellow(username)} joined ${chalk.cyan(room)}`
+  const message: string = `${username} joined ${room}`
+
   sendToRoom(message, room, socket)
 }
 

--- a/src/events/event-handlers/handle-disconnect.ts
+++ b/src/events/event-handlers/handle-disconnect.ts
@@ -6,10 +6,7 @@ import population from '../lib/population'
 /**
  * Removes the user from the population memory pool
  * and performs other cleanup
- * @exports
- * @function
- * @name handleDisconnect
- * @param socket {Socket} The socket object from the client event
+ * @param socket The socket object from the client event
  */
 const handleDisconnect = (socket: Socket): void => {
   try {

--- a/src/events/event-handlers/handle-input.ts
+++ b/src/events/event-handlers/handle-input.ts
@@ -6,12 +6,9 @@ import handleMessage from './handle-message'
 /***
  * Passes input to handleCommand or handleMessage
  * depending on whether the input has a leading slash.
- * @exports
- * @function
- * @name handleInput
- * @param line {string} The input from the client
- * @param socket {Socket} The socket object from the client event
- * @param io {Server} The server-side Socket.io instance
+ * @param line The input from the client
+ * @param socket The socket object from the client event
+ * @param io The server-side Socket.io instance
  ***/
 const handleInput = (line: string, socket: Socket, io: Server): void => {
   console.log('Received input:', line)

--- a/src/events/event-handlers/handle-message.ts
+++ b/src/events/event-handlers/handle-message.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import { Socket } from 'socket.io'
 
 import { TRoomName, TUsername } from '../../types/global'
@@ -10,16 +9,13 @@ import sendToRoom from '../lib/send-to-room'
  * This function should be expanded to parse emojis,
  * filter for length and spamming, and provide
  * other chat moderation features.
- * @exports
- * @function
- * @name handleMessage
- * @param line {string} The user's public chat message
- * @param socket {Socket} The socket object from the client event
+ * @param line The user's public chat message
+ * @param socket The socket object from the client event
  */
 const handleMessage = (line: string, socket: Socket): void => {
   const username: TUsername = population.getUsername(socket.id)
   const room: TRoomName = population.getRoom(socket.id)
-  const designator: string = chalk.yellow(`‹${username}›`)
+  const designator: string = `‹${username}›`
   const message: string = `${designator} ${line}`
 
   sendToRoom(message, room, socket)


### PR DESCRIPTION
- [x] `chalk` is a command-line coloring package, and it should not be used to color output to the new Hubbub React client. This is part of the conversion of Hubbub from a CLI to full stack package
- [x] `emojic`, used for emoji, does not have a @types package and much be replaced
- [x] Includes fixes to doc comments in changed files
- [x] Includes other small fixes in the package.json and jest.config.js